### PR TITLE
Inline entries in topic pages

### DIFF
--- a/pyjournal2/build_util.py
+++ b/pyjournal2/build_util.py
@@ -72,25 +72,24 @@ def build(defs, show=0):
                 yf.write("{}\n".format(y))
                 yf.write("****\n\n")
 
-                yf.write(".. toctree::\n")
-                yf.write("   :maxdepth: 2\n")
-                yf.write("   :caption: Contents:\n\n")
+                # yf.write(".. toctree::\n")
+                # yf.write("   :maxdepth: 2\n")
+                # yf.write("   :caption: Contents:\n\n")
+
+                # for entry in y_entries:
+                #     yf.write("   {}/{}.rst\n".format(entry, entry))
 
                 for entry in y_entries:
-                    yf.write("   {}/{}.rst\n".format(entry, entry))
+                    yf.write(".. include:: {}/{}.rst\n".format(entry, entry))
 
         # now write the topic.rst
         with open("{}.rst".format(topic), "w") as tf:
-            tf.write(len(topic)*"*" + "\n")
+            tf.write(len(topic)*"#" + "\n")
             tf.write("{}\n".format(topic))
-            tf.write(len(topic)*"*" + "\n")
-
-            tf.write(".. toctree::\n")
-            tf.write("   :maxdepth: 2\n")
-            tf.write("   :caption: Contents:\n\n")
+            tf.write(len(topic)*"#" + "\n")
 
             for y in years:
-                tf.write("   {}.rst\n".format(y))
+                tf.write(".. include:: {}.rst\n".format(y))
 
 
     # now write the index.rst

--- a/pyjournal2/entry_util.py
+++ b/pyjournal2/entry_util.py
@@ -84,7 +84,7 @@ def entry(topic, images, link_file, defs, string=None):
 
     entry_file = os.path.join(odir, ofile)
     if not os.path.isfile(entry_file):
-        header = len(entry_dir)*"*" + "\n" + "{}\n".format(entry_dir) + len(entry_dir)*"*" + "\n"
+        header = len(entry_dir)*"=" + "\n" + "{}\n".format(entry_dir) + len(entry_dir)*"=" + "\n"
         header += SYMBOLS + "\n\n"
     else:
         header = ""

--- a/pyjournal2/entry_util.py
+++ b/pyjournal2/entry_util.py
@@ -146,7 +146,7 @@ def entry(topic, images, link_file, defs, string=None, use_date=None):
                 # add the figure text
                 for l in FIGURE_STR.split("\n"):
                     f.write("{}\n".format(
-                        l.replace("@figname@", im_copy).replace("@figlabel@", im0).rstrip()))
+                        l.replace("@figname@", "/{}/{}/{}".format(topic, entry_dir, im_copy)).replace("@figlabel@", im0).rstrip()))
 
             else:
                 # add the download directive

--- a/pyjournal2/entry_util.py
+++ b/pyjournal2/entry_util.py
@@ -150,7 +150,7 @@ def entry(topic, images, link_file, defs, string=None, use_date=None):
 
             else:
                 # add the download directive
-                f.write(":download:`{} <{}>`\n\n".format(im_copy, im_copy))
+                f.write(":download:`{} </{}/{}/{}>`\n\n".format(im_copy, topic, entry_dir, im_copy))
 
     f.close()
 


### PR DESCRIPTION
Not sure if you will want to accept the PR, for me it is a style choice.

I wanted the entry contents inlined in each topic page so I can read them all together instead of having to remember what entry was what.

Also adds an empty `mathsymbols.tex` file - it's missing from pyjournal and without it the build fails. Probably I should have PR'd that separately...

So now, instead of:

![pyjournal](https://user-images.githubusercontent.com/6532013/54787640-91f92c00-4be9-11e9-943a-b5256d9138c9.png)

It looks like:

![pyjournal_inlined](https://user-images.githubusercontent.com/6532013/54787642-9887a380-4be9-11e9-8292-86369a960eae.png)
